### PR TITLE
Fixed issue:s with stone pressure plates

### DIFF
--- a/.idea/boost-pads.iml
+++ b/.idea/boost-pads.iml
@@ -11,6 +11,8 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.spigotmc:spigot-api:1.11.2-R0.1-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.md-5:bungeecord-chat:1.10-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.spigotmc:spigot-api:1.11.2-R0.1-SNAPSHOT" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: commons-lang:commons-lang:2.6" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.googlecode.json-simple:json-simple:1.1.1" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: junit:junit:4.10" level="project" />

--- a/src/main/java/net/scoutlink/boostpads/Main.java
+++ b/src/main/java/net/scoutlink/boostpads/Main.java
@@ -77,10 +77,8 @@ public class Main extends JavaPlugin implements Listener {
         Player player = event.getPlayer();
         if (event.getAction() == Action.PHYSICAL && !event.isCancelled()) {
             if (event.getClickedBlock().getType() == Material.STONE_PLATE) {
-                Block block = player.getLocation().add(0.0D, -2.0D, 0.0D).getBlock();
-                if (player.getLocation().add(0.0D, -2.0D, 0.0D).getBlock().getType() == Material.SIGN ||
-                        player.getLocation().add(0.0D, -2.0D, 0.0D).getBlock().getType() == Material.SIGN_POST ||
-                        player.getLocation().add(0.0D, -2.0D, 0.0D).getBlock().getType() == Material.WALL_SIGN) {
+                Block block = event.getClickedBlock().getLocation().add(0.0D, -2.0D, 0.0D).getBlock();
+                if (block.getType() == Material.SIGN || block.getType() == Material.SIGN_POST || block.getType() == Material.WALL_SIGN) {
                     BlockState stateBlock = block.getState();
                     Sign sign = (Sign) stateBlock;
                     if (sign.getLine(0).equals(ChatColor.GRAY + "[" + ChatColor.DARK_RED + "Boost" + ChatColor.GRAY + "]")) {


### PR DESCRIPTION
Stone pressure plates now work correctly:
- Searching for the sign beneath the plate from the location of the player didn't work
- The sign is now found based on the location of the pressure plate that is triggered
Changed other code to use block variable